### PR TITLE
feat: Foundation.UUIDを@retroactiveでLosslessStringConvertibleに準拠させる

### DIFF
--- a/Sources/EventStoreAdapterSupport/UUID+LosslessStringConvertible.swift
+++ b/Sources/EventStoreAdapterSupport/UUID+LosslessStringConvertible.swift
@@ -1,0 +1,20 @@
+public import Foundation
+
+/// `Foundation.UUID`を`@retroactive`キーワードで`LosslessStringConvertible`に準拠させる拡張
+///
+/// Event Sourcingにおいて、イベントIDやAggregate IDとして`UUID`を頻繁に使用し、
+/// 文字列との相互変換が必要な場面が多いため、より直感的なAPIを提供します。
+///
+/// ```swift
+/// let uuid = UUID()
+/// let string = String(uuid)
+/// let restored = UUID(string)
+/// ```
+extension UUID: @retroactive LosslessStringConvertible {
+    /// 文字列からUUIDを初期化する
+    ///
+    /// - Parameter description: UUID文字列表現
+    public init?(_ description: String) {
+        self.init(uuidString: description)
+    }
+}

--- a/Tests/EventStoreAdapterSupportTests/EventStoreAdapterSupportTests.swift
+++ b/Tests/EventStoreAdapterSupportTests/EventStoreAdapterSupportTests.swift
@@ -65,12 +65,3 @@ import Testing
     #expect(event.occurredAt == ISO8601DateFormatter().date(from: "2022-01-01T00:00:00Z")!)
     #expect(event.isCreated == true)
 }
-
-extension UUID: @retroactive LosslessStringConvertible {
-    init?(_ description: String) {
-        self.init(uuidString: description)
-    }
-    var description: String {
-        uuidString
-    }
-}

--- a/Tests/EventStoreAdapterSupportTests/UUIDLosslessStringConvertibleTests.swift
+++ b/Tests/EventStoreAdapterSupportTests/UUIDLosslessStringConvertibleTests.swift
@@ -26,7 +26,7 @@ struct UUIDLosslessStringConvertibleTests {
         let uuid = UUID(uuidString)
         #expect(uuid != nil)
 
-        if let uuid = uuid {
+        if let uuid {
             let restored = String(uuid)
             #expect(restored.uppercased() == uuidString.uppercased())
         }

--- a/Tests/EventStoreAdapterSupportTests/UUIDLosslessStringConvertibleTests.swift
+++ b/Tests/EventStoreAdapterSupportTests/UUIDLosslessStringConvertibleTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import EventStoreAdapterSupport
+
+struct UUIDLosslessStringConvertibleTests {
+
+    @Test func UUIDの文字列変換と復元が正しく動作する() {
+        let original = UUID()
+        let string = String(original)
+        let restored = UUID(string)
+
+        #expect(original == restored)
+        #expect(string == original.uuidString)
+    }
+
+    @Test(
+        arguments: [
+            "550E8400-E29B-41D4-A716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "00000000-0000-0000-0000-000000000000",
+            "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+        ]
+    )
+    func 有効なUUID文字列形式から正しくUUIDを生成できる(uuidString: String) {
+        let uuid = UUID(uuidString)
+        #expect(uuid != nil)
+
+        if let uuid = uuid {
+            let restored = String(uuid)
+            #expect(restored.uppercased() == uuidString.uppercased())
+        }
+    }
+
+    @Test(
+        arguments: [
+            "",
+            "not-a-uuid",
+            "550E8400-E29B-41D4-A716",
+            "550E8400-E29B-41D4-A716-446655440000-EXTRA",
+            "550E8400-E29B-41D4-A716-44665544000G",
+            "550E8400E29B41D4A716446655440000",
+            "550E8400-E29B-41D4-A716-44665544000",
+            "550E8400-E29B-41D4-A716-4466554400000",
+            "550E8400-E29B-41D4-A716-446655440000 ",
+            " 550E8400-E29B-41D4-A716-446655440000",
+        ]
+    )
+    func 無効なUUID文字列からはnilが返される(invalidString: String) {
+        let result = UUID(invalidString)
+        #expect(result == nil, "Expected nil for invalid UUID string: '\(invalidString)'")
+    }
+
+    @Test(arguments: 1...100)
+    func ランダムなUUIDでの往復変換が正しく動作する(iteration: Int) {
+        let original = UUID()
+        let string = String(original)
+        let restored = UUID(string)
+
+        #expect(
+            original == restored, "Round trip failed for UUID: \(original) (iteration \(iteration))"
+        )
+    }
+}


### PR DESCRIPTION
## 概要

`Foundation.UUID`を`@retroactive`キーワードを使用して`LosslessStringConvertible`プロトコルに準拠させる機能を追加しました。

Closes #5

## 変更内容

### 新規追加ファイル

- `Sources/EventStoreAdapterSupport/UUID+LosslessStringConvertible.swift`
  - `UUID`の`LosslessStringConvertible`準拠を実装
  - `@retroactive`キーワードで第三者による遡及的準拠として実装
  - `public import Foundation`で適切にFoundationを公開

- `Tests/EventStoreAdapterSupportTests/UUIDLosslessStringConvertibleTests.swift`
  - Swift Testingの`arguments`を使用したパラメータ化テストを実装
  - 115個のテストケースで包括的にカバー

### 既存ファイルの修正

- `Tests/EventStoreAdapterSupportTests/EventStoreAdapterSupportTests.swift`
  - 重複する`UUID`の`LosslessStringConvertible`準拠を削除

## 実装の特徴

- **最小限の実装**: `UUID`は既に`CustomStringConvertible`に準拠しているため、`init?(_ description: String)`の追加のみで準拠完了
- **@retroactiveキーワード**: 第三者による遡及的準拠として警告なく動作
- **将来対応**: Swift 6.2で標準対応される可能性があるため、将来の移行もスムーズ

## 使用例

```swift
import EventStoreAdapterSupport

let uuid = UUID()
let string = String(uuid)      // より簡潔な文字列化
let restored = UUID(string)    // より簡潔な復元
```

## テスト

- ✅ 基本的な往復変換テスト
- ✅ 有効なUUID形式のテスト（4ケース）
- ✅ 無効なUUID文字列のテスト（10ケース）
- ✅ ランダムUUIDでの往復変換テスト（100ケース）

## 動作確認

- ✅ `swift build` 成功
- ✅ `swift test` 成功（10テスト、115テストケース）
- ✅ `swift format -i -r .` 実行
- ✅ `swift format lint -r .` 成功

## メリット

1. **開発者体験の向上**: `String(uuid)`、`UUID("string")`で簡潔に変換可能
2. **Event Sourcingとの親和性**: IDの文字列化処理が簡潔になる
3. **将来対応**: Swift標準ライブラリでの対応時の移行がスムーズ